### PR TITLE
Restarting containers on ConfigMap updates, using livenessProbes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:latest
-COPY requirements.txt app.py /
+COPY requirements.txt /
 RUN pip install -r requirements.txt
-CMD gunicorn -b 0.0.0.0 --log-level debug app:api
+COPY app.py config_update_check.py /
+CMD gunicorn -b 0.0.0.0:8000 --log-level debug app:api

--- a/LIVENESS-PROBE-RESTART-README.md
+++ b/LIVENESS-PROBE-RESTART-README.md
@@ -23,8 +23,8 @@ docker build -t devops-sig-app .
 
 Apply configmap and app pod:
 ```bash
-kubectl apply -f env-rendering/configmap.yml  
-kubectl apply -f env-rendering/myapp.yml
+kubectl apply -f liveness-probe-restart/configmap.yml  
+kubectl apply -f liveness-probe-restart/myapp.yml
 ```
 
 To observe results, forward minikube ports in one shell:
@@ -37,9 +37,9 @@ In another shell:
 watch -n 1 curl localhost:8000/var
 ```
 
-Now change MAGIC value in the env-rendering/configmap.yml and run:
+Now change MAGIC value in the liveness-probe-restart/configmap.yml and run:
 ```bash
-kubectl apply -f env-rendering/configmap.yml  
+kubectl apply -f liveness-probe-restart/configmap.yml  
 ```
 
 After around 20-30 seconds, configmap value is updated on the node.

--- a/LIVENESS-PROBE-RESTART-README.md
+++ b/LIVENESS-PROBE-RESTART-README.md
@@ -1,5 +1,5 @@
 The basic idea is to use a livenessProbe to restart a container when files in a specified config 
-directory change (f.e. because of a change in a ConfigMap attached as a volume).
+directory change (f.e. because of a change in a ConfigMap attached as a volume, ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically ).
 
 app.py reads a 'MAGIC' value from the /etc/app/config.yml file at the start. It is then available via the http server at \<ip>:8000/var.
 
@@ -42,7 +42,7 @@ Now change MAGIC value in the liveness-probe-restart/configmap.yml and run:
 kubectl apply -f liveness-probe-restart/configmap.yml  
 ```
 
-After around 20-30 seconds, configmap value is updated on the node.
+After around 20-30 seconds, configmap value is updated on the node (this time can be shortened by changing appropriate flags for kubelet).
 After that, the config_update_check.py script used in the livenessProbe should fail, and trigger
 a restart of the container. You can observe it by running:
 ```bash

--- a/LIVENESS-PROBE-RESTART-README.md
+++ b/LIVENESS-PROBE-RESTART-README.md
@@ -1,0 +1,53 @@
+The basic idea is to use a livenessProbe to restart a container when files in a specified config 
+directory change (f.e. because of a change in a ConfigMap attached as a volume).
+
+app.py reads a 'MAGIC' value from the /etc/app/config.yml file at the start. It is then available via the http server at \<ip>:8000/var.
+
+config_update_check.py checks the modification time of a specified folder and stores it in a temporary file.
+If the registered value is larger then the previous one, script fails. By using this script in a
+livenessProbe defined for the app container, we can trigger restarts of the container when files in
+the config directory change.
+
+
+Setup commands (when using minikube):
+
+Use local docker images in the minikube cluster
+```bash
+eval $(minikube docker-env) 
+```
+
+Build docker images
+```bash
+docker build -t devops-sig-app .
+```
+
+Apply configmap and app pod:
+```bash
+kubectl apply -f env-rendering/configmap.yml  
+kubectl apply -f env-rendering/myapp.yml
+```
+
+To observe results, forward minikube ports in one shell:
+```bash
+kubectl port-forward myapp-pod 8000:8000 
+```
+
+In another shell:
+```
+watch -n 1 curl localhost:8000/var
+```
+
+Now change MAGIC value in the env-rendering/configmap.yml and run:
+```bash
+kubectl apply -f env-rendering/configmap.yml  
+```
+
+After around 20-30 seconds, configmap value is updated on the node.
+After that, the config_update_check.py script used in the livenessProbe should fail, and trigger
+a restart of the container. You can observe it by running:
+```bash
+kubectl describe pods myapp-pod
+```
+
+
+

--- a/app.py
+++ b/app.py
@@ -2,55 +2,36 @@
 import falcon
 import threading
 import time
-
-global_config_lock = threading.Lock()
-config = { 'magic_word': 'abc' }
+import yaml
 
 
-def dummy_config_changer():
-    try:
-        open('/etc/app/config.yaml', 'r')
-    except FileNotFoundError:
-        pass
-    i = 0
-    while True:
-        i += 1
-        time.sleep(10)
-        try:
-            #open('/var/run/app.lock', 'r')
-            print('GCL locking')
-            with global_config_lock:
-                config['magic_word'] = str(i)
-                print('GCL unlocking')
-        except Exception as e:
-            print('exc')
-    print("Thread %s: finishing")
-
-
-config_changers = {
-    'dummy_config_changer': dummy_config_changer
-}
+try:
+    with open('/etc/app/config.yml', 'r') as f:
+        print("Reading from config")
+        new_magic_word = yaml.load(f.read())['MAGIC']
+except FileNotFoundError:
+    print("FileNotFound")
+    new_magic_word = 'filenotfound'
+except KeyError:
+    print("KeyError")
+    new_magic_word = 'config key error'
 
 
 class VarResource:
     def on_get(self, req, resp):
-        with global_config_lock:
-            obj = {'todays_magic_word': config['magic_word']}
-            resp.media = obj
+            resp.media = {'magic_word': new_magic_word}
 
 
 class ConstResource:
     def on_get(self, req, resp):
-        resp.media = { 'devops_sig_no': 8 }
+        resp.media = {'devops_sig_no': 8}
 
 
 class TimeResource:
     def on_get(self, req, resp):
         resp.media = int(time.time())
 
-config_changer = 'dummy_config_changer'
-config_changer_thread = threading.Thread(target=config_changers[config_changer])
-config_changer_thread.start()
+
 api = falcon.API()
 api.add_route('/var', VarResource())
 api.add_route('/const', ConstResource())

--- a/config_update_check.py
+++ b/config_update_check.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import os
+
+CONFIGS_DIR = '/etc/app'
+TMP_FILE = '/tmp/config_change_time'
+
+current_config_m_time = int(os.path.getmtime(CONFIGS_DIR))
+
+# Try to read last save config dir modification time
+try:
+    with open(TMP_FILE, 'r') as f:
+        last_config_m_time = int(f.readline())
+except FileNotFoundError:
+    last_config_m_time = None
+
+# Write current config dir modification time
+with open(TMP_FILE, 'w') as f:
+    f.write(str(current_config_m_time))
+
+if last_config_m_time and current_config_m_time > last_config_m_time:
+    print("Config dir was modified since last check. Exiting with non-zero code.")
+    exit(1)
+else:
+    exit(0)
+
+
+

--- a/liveness-probe-restart/configmap.yml
+++ b/liveness-probe-restart/configmap.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: special-config
+  namespace: default
+data:
+  config.yml: |
+    MAGIC: hello1337

--- a/liveness-probe-restart/myapp.yml
+++ b/liveness-probe-restart/myapp.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+  labels:
+    app: myapp
+spec:
+  restartPolicy: Always
+  volumes:
+    - name: config-volume
+      configMap:
+        name: special-config
+  containers:
+  - name: myapp-container
+    image: devops-sig-app:latest
+    imagePullPolicy: Never
+    ports:
+      - containerPort: 8000
+    volumeMounts:
+      - name: config-volume
+        mountPath: /etc/app
+    livenessProbe:
+      exec:
+        command: ['/config_update_check.py']
+      initialDelaySeconds: 1
+      periodSeconds: 2
+      successThreshold: 1
+      failureThreshold: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 falcon
 gunicorn
+pyyaml


### PR DESCRIPTION
The basic idea is to use a livenessProbe to restart the application container when files in a specified config directory change (f.e. because of a change in a ConfigMap attached as a volume, ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically ).

app.py reads a 'MAGIC' value from the /etc/app/config.yml file at the
start. It is then available via the http server at \<ip>:8000/var.

config_update_check.py checks the modification time of a specified
folder and stores it in a temporary file. If the registered value is larger then the previous one, script fails.
By using this script in a livenessProbe defined for the app container, we can trigger restarts of the container when files in the config directory change.